### PR TITLE
ガイドの変更内容を反映

### DIFF
--- a/Runtime/MessagingClient.cs
+++ b/Runtime/MessagingClient.cs
@@ -15,12 +15,6 @@ namespace Extreal.Integration.Messaging
     public abstract class MessagingClient : DisposableBase
     {
         /// <summary>
-        /// IDs of joined clients.
-        /// </summary>
-        public IReadOnlyList<string> JoinedClients => joinedClients;
-        private readonly List<string> joinedClients = new List<string>();
-
-        /// <summary>
         /// <para>Invokes immediately after this client joined a group.</para>
         /// Arg: Client ID of this client.
         /// </summary>
@@ -163,14 +157,6 @@ namespace Extreal.Integration.Messaging
             OnLeaving
                 .Merge(OnUnexpectedLeft.Select(_ => Unit.Default))
                 .Subscribe(_ => isJoined = false)
-                .AddTo(disposables);
-
-            OnClientJoined
-                .Subscribe(joinedClients.Add)
-                .AddTo(disposables);
-
-            OnClientLeaving
-                .Subscribe(clientId => joinedClients.Remove(clientId))
                 .AddTo(disposables);
         }
 

--- a/Runtime/QueuingMessagingClient.cs
+++ b/Runtime/QueuingMessagingClient.cs
@@ -23,10 +23,9 @@ namespace Extreal.Integration.Messaging
         public IObservable<string> OnJoined => messagingClient.OnJoined;
 
         /// <summary>
-        /// <para>Invokes just before this client leaves a group.</para>
-        /// Arg: reason why this client leaves.
+        /// Invokes just before this client leaves a group.
         /// </summary>
-        public IObservable<string> OnLeaving => messagingClient.OnLeaving;
+        public IObservable<Unit> OnLeaving => messagingClient.OnLeaving;
 
         /// <summary>
         /// <para>Invokes immediately after this client unexpectedly leaves a group.</para>
@@ -79,7 +78,7 @@ namespace Extreal.Integration.Messaging
                 .AddTo(disposables);
 
             messagingClient.OnLeaving
-                .Merge(messagingClient.OnUnexpectedLeft)
+                .Merge(messagingClient.OnUnexpectedLeft.Select(_ => Unit.Default))
                 .Subscribe(_ => isJoined = false)
                 .AddTo(disposables);
 

--- a/Runtime/QueuingMessagingClient.cs
+++ b/Runtime/QueuingMessagingClient.cs
@@ -12,11 +12,6 @@ namespace Extreal.Integration.Messaging
     public class QueuingMessagingClient : DisposableBase
     {
         /// <summary>
-        /// IDs of joined clients.
-        /// </summary>
-        public IReadOnlyList<string> JoinedClients => messagingClient.JoinedClients;
-
-        /// <summary>
         /// <para>Invokes immediately after this client joined a group.</para>
         /// Arg: Client ID of this client.
         /// </summary>

--- a/Tests/Runtime/QueuingMessagingClientTest.cs
+++ b/Tests/Runtime/QueuingMessagingClientTest.cs
@@ -36,7 +36,7 @@ namespace Extreal.Integration.Messaging.Test
                 .AddTo(disposables);
 
             queuingMessagingClient.OnLeaving
-                .Subscribe(eventHandler.SetLeavingReason)
+                .Subscribe(_ => eventHandler.SetIsLeaving(true))
                 .AddTo(disposables);
 
             queuingMessagingClient.OnUnexpectedLeft
@@ -134,11 +134,11 @@ namespace Extreal.Integration.Messaging.Test
             var joiningConfig = new MessagingJoiningConfig("MessagingTest");
             await queuingMessagingClient.JoinAsync(joiningConfig);
 
-            Assert.That(eventHandler.LeavingReason, Is.Null);
+            Assert.That(eventHandler.IsLeaving, Is.False);
 
             await queuingMessagingClient.LeaveAsync();
 
-            Assert.That(eventHandler.LeavingReason, Is.EqualTo("leave request"));
+            Assert.That(eventHandler.IsLeaving, Is.True);
         });
 
         [Test]
@@ -250,9 +250,9 @@ namespace Extreal.Integration.Messaging.Test
             public void SetClientId(string clientId)
                 => ClientId = clientId;
 
-            public string LeavingReason { get; private set; }
-            public void SetLeavingReason(string reason)
-                => LeavingReason = reason;
+            public bool IsLeaving { get; private set; }
+            public void SetIsLeaving(bool isLeaving)
+                => IsLeaving = isLeaving;
 
             public string UnexpectedLeftReason { get; private set; }
             public void SetUnexpectedLeftReason(string reason)
@@ -281,7 +281,7 @@ namespace Extreal.Integration.Messaging.Test
             public void Clear()
             {
                 SetClientId(default);
-                SetLeavingReason(default);
+                SetIsLeaving(default);
                 SetUnexpectedLeftReason(default);
                 SetIsJoiningApprovalRejected(default);
                 SetJoinedClientId(default);

--- a/Tests/Runtime/QueuingMessagingClientTest.cs
+++ b/Tests/Runtime/QueuingMessagingClientTest.cs
@@ -153,23 +153,18 @@ namespace Extreal.Integration.Messaging.Test
         public void ClientJoined()
         {
             Assert.That(eventHandler.JoinedClientId, Is.Null);
-            Assert.That(queuingMessagingClient.JoinedClients.Count, Is.Zero);
             messagingClient.FireOnClientJoined();
             Assert.That(eventHandler.JoinedClientId, Is.EqualTo(otherClientId));
-            Assert.That(queuingMessagingClient.JoinedClients.Count, Is.EqualTo(1));
-            Assert.That(queuingMessagingClient.JoinedClients[0], Is.EqualTo(eventHandler.JoinedClientId));
         }
 
         [Test]
         public void ClientLeaving()
         {
             messagingClient.FireOnClientJoined();
-            Assert.That(queuingMessagingClient.JoinedClients.Count, Is.EqualTo(1));
 
             Assert.That(eventHandler.LeavingClientId, Is.Null);
             messagingClient.FireOnClientLeaving();
             Assert.That(eventHandler.LeavingClientId, Is.EqualTo(otherClientId));
-            Assert.That(queuingMessagingClient.JoinedClients.Count, Is.Zero);
         }
 
         [UnityTest]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jp.co.tis.extreal.integration.messaging",
-  "version": "1.0.0-next.3",
+  "version": "1.0.0-next.4",
   "displayName": "Extreal.Integration.Messaging",
   "unity": "2022.3",
   "author": {


### PR DESCRIPTION
# 何の変更を加えましたか？

- LeavingReason を削除しました
  - 固定文字列を返していたため
- JoinedClients を削除しました
  - どこでも使用していなかったため

# 何を確認しましたか?

## 実装

- [x] Frameworkの誤った使い方にすぐに気づけるように、無効な引数や無効なメソッド呼び出しに対するチェックが入っていることを確認しました
- [x] Framework実行時の動きが分かるように、ログ（Error/Warn/Info/Debug）を出力していることを確認しました
- [x] 静的解析で問題が見つからないことを確認しました
- [x] フレームワーク利用者が使うAPI（主にprivate以外）に C# ドキュメントを記述しました

## テスト

- [x] 全ての自動テストが成功することを確認しました
- [x] テストカバレッジが100%になることを確認しました
- [x] サンプルがあるものはサンプルが動作することを確認しました
    - サンプルはなし 

## 変更影響

https://github.com/extreal-dev/Extreal.Guide/pull/56
- [x] GuideのReleaseページに変更内容が追加されることを確認しました
- [ ] GuideのModuleページ（機能ページ）に変更が反映されることを確認しました
- [x] GuideのLearningページに変更が反映されることを確認しました
- [x] Sample Applicationに変更が反映されることを確認しました

# レビュアーへのメッセージ
